### PR TITLE
Add endpoint for missing crafting materials

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -11,5 +11,6 @@ router.delete('/:user_id/inventory/:item_id', userInventoryController.deleteInve
 
 // 제작 가능 아이템 라우트
 router.get('/:user_id/craftable-items', craftingController.getCraftableItems);
+router.get('/:user_id/missing-materials/:recipe_id', craftingController.getMissingMaterials);
 
 module.exports = router; 


### PR DESCRIPTION
## Summary
- compute required materials against user inventory
- expose `getMissingMaterials` in API and routing

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684902cb83808333ab04cce841c24f86