### PR TITLE
Add endpoint for missing crafting materials

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4,11 +4,13 @@ const cors = require('cors'); // CORS 미들웨어를 불러옵니다.
 const itemRoutes = require('./routes/itemRoutes'); // itemRoutes 모듈을 불러옵니다.
 const craftingRoutes = require('./routes/craftingRoutes'); // craftingRoutes 모듈을 불러옵니다.
 const userRoutes = require('./routes/userRoutes'); // 새로운 userRoutes 모듈을 불러옵니다.
+const path = require('path');
 const app = express();
 const port = 3001;
 
 app.use(express.json());
 app.use(cors()); // 모든 도메인에서의 요청을 허용합니다.
+app.use(express.static(path.join(__dirname, '../frontend')));
 
 // 데이터베이스 연결 설정 (실제 사용 시에는 .env 파일 등을 통해 관리)
 const dbConfig = {
@@ -40,9 +42,11 @@ async function initializeDatabase() {
 // 서버 시작 전 데이터베이스 초기화
 initializeDatabase();
 
+// 정적 프론트엔드 파일 제공
 app.get('/', (req, res) => {
-  res.send('마비노기 아이템 데이터베이스 API 서버입니다.');
+  res.sendFile(path.join(__dirname, '../frontend/index.html'));
 });
+
 
 // 기존의 /items 엔드포인트는 itemRoutes로 대체됩니다.
 // app.get('/items', async (req, res) => {

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -11,5 +11,6 @@ router.delete('/:user_id/inventory/:item_id', userInventoryController.deleteInve
 
 // 제작 가능 아이템 라우트
 router.get('/:user_id/craftable-items', craftingController.getCraftableItems);
+router.get('/:user_id/missing-materials/:recipe_id', craftingController.getMissingMaterials);
 
 module.exports = router; 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Frontend Usage
+
+This simple page provides a minimal interface for managing your inventory and
+checking which items you can craft. It relies on the backend Express server
+running on the same origin.
+
+Open `index.html` in a modern browser. It will fetch the inventory for user `1`
+and display editable quantities. Use the "저장" buttons to update amounts, then
+click "제작 가능 아이템 보기" to load craftable recipes. For each recipe you can
+check which materials you are missing.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>제작 계산기</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-100 p-4">
+    <div class="max-w-4xl mx-auto">
+        <h1 class="text-2xl font-bold mb-4">내 아이템 관리</h1>
+        <table id="inventoryTable" class="min-w-full bg-white shadow mb-6">
+            <thead>
+                <tr>
+                    <th class="px-2 py-1">아이템</th>
+                    <th class="px-2 py-1">수량</th>
+                    <th class="px-2 py-1">변경</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+        <button id="refreshCraftable" class="bg-blue-600 text-white px-4 py-2 rounded">제작 가능 아이템 보기</button>
+        <div id="craftableList" class="mt-4 space-y-2"></div>
+    </div>
+
+<script>
+const USER_ID = 1;
+async function loadInventory() {
+    const res = await fetch(`/users/${USER_ID}/inventory`);
+    const data = await res.json();
+    const tbody = document.querySelector('#inventoryTable tbody');
+    tbody.innerHTML = '';
+    data.forEach(item => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td class="border px-2 py-1 flex items-center space-x-2">
+                ${item.icon_url ? `<img src="${item.icon_url}" class="w-6 h-6"/>` : ''}
+                <span>${item.item_name}</span>
+            </td>
+            <td class="border px-2 py-1"><input type="number" min="0" value="${item.quantity}" class="w-20 border" /></td>
+            <td class="border px-2 py-1"><button class="bg-green-600 text-white px-2 py-1 rounded save-btn" data-item="${item.item_id}">저장</button></td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+async function updateQuantity(itemId, quantity) {
+    await fetch(`/users/${USER_ID}/inventory/${itemId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ quantity: Number(quantity) })
+    });
+}
+
+document.addEventListener('click', async (e) => {
+    if (e.target.classList.contains('save-btn')) {
+        const itemId = e.target.dataset.item;
+        const qtyInput = e.target.closest('tr').querySelector('input');
+        await updateQuantity(itemId, qtyInput.value);
+        loadInventory();
+    } else if (e.target.classList.contains('missing-btn')) {
+        const recipeId = e.target.dataset.recipe;
+        const res = await fetch(`/users/${USER_ID}/missing-materials/${recipeId}`);
+        const data = await res.json();
+        alert(data.materials.map(m => `${m.name}: ${m.missing_quantity}`).join('\n'));
+    }
+});
+
+document.getElementById('refreshCraftable').addEventListener('click', async () => {
+    const res = await fetch(`/users/${USER_ID}/craftable-items`);
+    const data = await res.json();
+    const container = document.getElementById('craftableList');
+    container.innerHTML = '';
+    data.forEach(recipe => {
+        const div = document.createElement('div');
+        div.className = 'bg-white p-2 shadow flex items-center justify-between';
+        div.innerHTML = `
+            <div class="flex items-center space-x-2">
+                ${recipe.result_item_icon_url ? `<img src="${recipe.result_item_icon_url}" class="w-6 h-6"/>` : ''}
+                <span>${recipe.result_item_name} (제작 가능: ${recipe.craftable_quantity})</span>
+            </div>
+            <button class="bg-gray-700 text-white px-2 py-1 rounded missing-btn" data-recipe="${recipe.recipe_id}">부족 재료</button>`;
+        container.appendChild(div);
+    });
+});
+
+loadInventory();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- compute required materials against user inventory
- expose `getMissingMaterials` in API and routing
- add basic Tailwind frontend to update inventory and view craftable items
- serve frontend assets from Express backend

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684902cb83808333ab04cce841c24f86